### PR TITLE
Laravel 9 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,12 +13,14 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.0]
-        laravel: [8.*]
+        php: [8.1, 8.0]
+        laravel: [^8.71, 9.*]
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 8.*
-            testbench: ^6.6
+          - laravel: 9.*
+            testbench: 7.*
+          - laravel: ^8.71
+            testbench: 6.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
         "illuminate/contracts": "^8.37|^9"
     },
     "require-dev": {
-        "nunomaduro/collision": "^5.3",
-        "orchestra/testbench": "^6.15",
+        "nunomaduro/collision": "^5.3|^6.1",
+        "orchestra/testbench": "^6.15|^7.0",
         "pestphp/pest": "^1.18",
         "pestphp/pest-plugin-laravel": "^1.1",
         "spatie/laravel-ray": "^1.23",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.0",
         "spatie/laravel-package-tools": "^1.4.3",
-        "illuminate/contracts": "^8.37"
+        "illuminate/contracts": "^8.37|^9"
     },
     "require-dev": {
         "nunomaduro/collision": "^5.3",


### PR DESCRIPTION
Hello @Larsklopstra!

This PR allows the package to be installed in Laravel 9.
Additionally, it updates the test suite for running on PHP 8.1 and Laravel 9.

The minimum required version of Laravel is now 8.71 (because early versions of Laravel 8 don't support PHP 8.1).

Resolves: #5 