### PR TITLE
Make datapoint alias customizable

### DIFF
--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -77,3 +77,22 @@ You can use the following aggregates:
 -   `max('column')`
 -   `min('column')`
 -   `count('*')`
+
+## Settings
+
+You can use the following settings:
+
+- `dataColumn('column')`
+- `datapointAlias('alias')`
+
+### dateColumn()  
+The trend will per default be based on the 'created_at' attribute of your model.
+You can change this to use another field by using ```->dateColumn()```:
+
+- `datecolumn('column')`
+
+### datapointAlias()
+If your model already contains a field names ```date``` you will have to set the ```datapointAlias``` to something else.
+The value should not an existing field in your table or a reserved word.
+
+- `datapointAlias('datapointAlias')`

--- a/src/Trend.php
+++ b/src/Trend.php
@@ -134,7 +134,7 @@ class Trend
 
     public function mapValuesToDates(Collection $values): Collection
     {
-        $values = $values->map(fn ($value)  => new TrendValue(
+        $values = $values->map(fn ($value) => new TrendValue(
             date: $value->{$this->datapointAlias},
             aggregate: $value->aggregate,
         ));


### PR DESCRIPTION
Previously the aggregate() function would use the keyword `date` as a temporary column name. This would interfere with tables that already contain a column name `date`. 
This PR make the temporary column name customizable, but keeps `date` as the default to avoid a potential breaking change.
Fix #8 