### PR TITLE
Add betweenTimestamp() function

### DIFF
--- a/src/Adapters/AbstractAdapter.php
+++ b/src/Adapters/AbstractAdapter.php
@@ -4,5 +4,5 @@ namespace Flowframe\Trend\Adapters;
 
 abstract class AbstractAdapter
 {
-    abstract public function format(string $column, string $interval): string;
+    abstract public function format(string $column, string $interval, bool $isTimestamp): string;
 }

--- a/src/Adapters/MySqlAdapter.php
+++ b/src/Adapters/MySqlAdapter.php
@@ -6,7 +6,7 @@ use Error;
 
 class MySqlAdapter extends AbstractAdapter
 {
-    public function format(string $column, string $interval): string
+    public function format(string $column, string $interval, bool $isTimestamp): string
     {
         $format = match ($interval) {
             'minute' => '%Y-%m-%d %H:%i:00',
@@ -16,6 +16,10 @@ class MySqlAdapter extends AbstractAdapter
             'year' => '%Y',
             default => throw new Error('Invalid interval.'),
         };
+
+        if ($isTimestamp) {
+            return "date_format(from_unixtime({$column}), '{$format}')";
+        }
 
         return "date_format({$column}, '{$format}')";
     }

--- a/src/Adapters/PgsqlAdapter.php
+++ b/src/Adapters/PgsqlAdapter.php
@@ -6,7 +6,7 @@ use Error;
 
 class PgsqlAdapter extends AbstractAdapter
 {
-    public function format(string $column, string $interval): string
+    public function format(string $column, string $interval, bool $isTimestamp): string
     {
         $format = match ($interval) {
             'minute' => 'YYYY-MM-DD HH24:MI:00',
@@ -16,6 +16,10 @@ class PgsqlAdapter extends AbstractAdapter
             'year' => 'YYYY',
             default => throw new Error('Invalid interval.'),
         };
+
+        if ($isTimestamp) {
+            return "to_char(to_timestamp({$column}), '{$format}')";
+        }
 
         return "to_char({$column}, '{$format}')";
     }

--- a/src/Adapters/SqliteAdapter.php
+++ b/src/Adapters/SqliteAdapter.php
@@ -6,7 +6,7 @@ use Error;
 
 class SqliteAdapter extends AbstractAdapter
 {
-    public function format(string $column, string $interval): string
+    public function format(string $column, string $interval, bool $isTimestamp): string
     {
         $format = match ($interval) {
             'minute' => '%Y-%m-%d %H:%M:00',
@@ -16,6 +16,10 @@ class SqliteAdapter extends AbstractAdapter
             'year' => '%Y',
             default => throw new Error('Invalid interval.'),
         };
+
+        if ($isTimestamp) {
+            return "strftime(datetime('{$format}', 'unixepoch'), {$column})";
+        }
 
         return "strftime('{$format}', {$column})";
     }


### PR DESCRIPTION
Sometimes, we store timestamp in database as UNIX Timestamp not `Y-m-d H:i:s` format, so I create betweenTimestamp() function to support it and do some adjustment in Adapters and Trend class.