### PR TITLE
Placeholders with custom date format

### DIFF
--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -77,3 +77,16 @@ You can use the following aggregates:
 -   `max('column')`
 -   `min('column')`
 -   `count('*')`
+
+## Placeholders
+
+You can also get the placeholders in your decired [date format](https://www.php.net/manual/en/datetime.format.php):
+
+```php
+$trend = Trend::model(...)
+    ->between(...)
+    ->perDay();
+
+$placeholders = $trend->placeholders('D');
+$totals = $trend->count();
+```

--- a/src/Trend.php
+++ b/src/Trend.php
@@ -123,6 +123,16 @@ class Trend
         return $this->aggregate($column, 'count');
     }
 
+    public function placeholders(string $format): Collection
+    {
+        return $this->getDatePeriod()->map(
+            fn (Carbon $date) => new TrendValue(
+                date: $date->format($format),
+                aggregate: 0,
+            )
+        );
+    }
+
     public function mapValuesToDates(Collection $values): Collection
     {
         $values = $values->map(fn ($value) => new TrendValue(
@@ -130,15 +140,8 @@ class Trend
             aggregate: $value->aggregate,
         ));
 
-        $placeholders = $this->getDatePeriod()->map(
-            fn (Carbon $date) => new TrendValue(
-                date: $date->format($this->getCarbonDateFormat()),
-                aggregate: 0,
-            )
-        );
-
         return $values
-            ->merge($placeholders)
+            ->merge($this->placeholders($this->getCarbonDateFormat()))
             ->unique('date')
             ->sort()
             ->flatten();


### PR DESCRIPTION
The new `placeholders` method allows to get the placeholders as a collection in a custom date format for further use in diagrams and reports:

```php
$trend = Trend::model(...)
    ->between(...)
    ->perDay();

$placeholders = $trend->placeholders('D');
$totals = $trend->count();
```

Please let me know if a can support you in any way to merge these changes and thanks for your work. :tada: