### PR TITLE
Timezone support

### DIFF
--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -77,3 +77,18 @@ You can use the following aggregates:
 -   `max('column')`
 -   `min('column')`
 -   `count('*')`
+
+## Timezone support
+
+You can specify the timezone of the database and the timezone of the aggregation:
+
+```php
+$trend = Trend::model(...)
+    ->between(...)
+    ->perMonth()
+    ->convertTimezone(
+        from: 'UTC',
+        to: 'Europe/Amsterdam',
+    )
+    ->count();
+```

--- a/src/Adapters/MySqlAdapter.php
+++ b/src/Adapters/MySqlAdapter.php
@@ -6,6 +6,11 @@ use Error;
 
 class MySqlAdapter extends AbstractAdapter
 {
+    public function convertTimezone(string $column, string $from, string $to): string
+    {
+        return "convert_tz({$column}, '{$from}', '{$to}')";
+    }
+
     public function format(string $column, string $interval): string
     {
         $format = match ($interval) {

--- a/src/Adapters/PgsqlAdapter.php
+++ b/src/Adapters/PgsqlAdapter.php
@@ -6,6 +6,11 @@ use Error;
 
 class PgsqlAdapter extends AbstractAdapter
 {
+    public function convertTimezone(string $column, string $from, string $to): string
+    {
+        return "{$column} at time zone '{$from}' at time zone '{$to}')";
+    }
+
     public function format(string $column, string $interval): string
     {
         $format = match ($interval) {

--- a/src/Adapters/SqliteAdapter.php
+++ b/src/Adapters/SqliteAdapter.php
@@ -6,6 +6,11 @@ use Error;
 
 class SqliteAdapter extends AbstractAdapter
 {
+    public function convertTimezone(string $column, string $from, string $to): string
+    {
+        throw new Error('Timezone conversion not supported for SQLite.');
+    }
+
     public function format(string $column, string $interval): string
     {
         $format = match ($interval) {

--- a/src/Trend.php
+++ b/src/Trend.php
@@ -21,6 +21,10 @@ class Trend
 
     public string $dateColumn = 'created_at';
 
+    public string $fromTimezone;
+
+    public string $toTimezone;
+
     public function __construct(public Builder $builder)
     {
     }
@@ -78,6 +82,14 @@ class Trend
     public function dateColumn(string $column): self
     {
         $this->dateColumn = $column;
+
+        return $this;
+    }
+
+    public function convertTimezone(string $from, string $to): self
+    {
+        $this->fromTimezone = $from;
+        $this->toTimezone = $to;
 
         return $this;
     }
@@ -163,7 +175,15 @@ class Trend
             default => throw new Error('Unsupported database driver.'),
         };
 
-        return $adapter->format($this->dateColumn, $this->interval);
+        $sqlDate = isset($this->fromTimezone, $this->toTimezone)
+                       ? $adapter->convertTimezone(
+                           $this->dateColumn,
+                           $this->fromTimezone,
+                           $this->toTimezone,
+                       )
+                       : $this->dateColumn;
+
+        return $adapter->format($sqlDate, $this->interval);
     }
 
     protected function getCarbonDateFormat(): string


### PR DESCRIPTION
The method `convertTimezone` adds the ability to aggregate in a different timezone than the timezone of the database (closes #19):

```php
$trend = Trend::model(...)
    ->between(...)
    ->perMonth()
    ->convertTimezone(
        from: 'UTC',
        to: 'Europe/Amsterdam',
    )
    ->count();
```

Unfortunately, I couldn't find a way to convert the timezone for SQLite and therefore implemented an error message in that case. Additionally, I wasn't able to test these changes in pgSQL. Could please somebody verify the changes on a pgSQL database?