### PR TITLE
Prevents ambiguous date column when providing a JOIN query

### DIFF
--- a/src/Trend.php
+++ b/src/Trend.php
@@ -92,7 +92,7 @@ class Trend
                 {$this->getSqlDate()} as {$this->dateAlias},
                 {$aggregate}({$column}) as aggregate
             ")
-            ->whereBetween($this->dateColumn, [$this->start, $this->end])
+            ->whereBetween("{$this->builder->getModel()->getTable()}.$this->dateColumn", [$this->start, $this->end])
             ->groupBy($this->dateAlias)
             ->orderBy($this->dateAlias)
             ->get();
@@ -165,7 +165,7 @@ class Trend
             default => throw new Error('Unsupported database driver.'),
         };
 
-        return $adapter->format($this->dateColumn, $this->interval);
+        return $adapter->format("{$this->builder->getModel()->getTable()}.$this->dateColumn", $this->interval);
     }
 
     protected function getCarbonDateFormat(): string


### PR DESCRIPTION
As suggested in #18 by @ArnoudLier it would be great if the table name of the queried model could be prefixed to the date column. 

This prevents ambiguous column exceptions (like the one below) when providing a JOIN query.
```
SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'created_at' in field list is ambiguous
```