### PR TITLE
fix: error when using modified `dateAlias` value

### DIFF
--- a/src/Trend.php
+++ b/src/Trend.php
@@ -135,7 +135,7 @@ class Trend
     public function mapValuesToDates(Collection $values): Collection
     {
         $values = $values->map(fn ($value) => new TrendValue(
-            date: $value->date,
+            date: $value->{$this->dateAlias},
             aggregate: $value->aggregate,
         ));
 


### PR DESCRIPTION
Hello,

When changing the `dateAlias` property like so: 
```php
  return $trend
            ->dateAlias('aggregation_date')
            ->dateColumn('date')
            ->between(
                start: now()->sub($this->filter, 1),
                end: now(),
            );
```

 an errorException is thrown: 
```
Undefined property: stdClass::$date
```

Looking through recent issues and pull requests, I came across these  #13 and #28 .
I noticed the `mapValuesToDates()` was missing a required change: 
```php
        $values = $values->map(fn ($value) => new TrendValue(
            date: $value->{$this->dateAlias},
            aggregate: $value->aggregate,
        ));
```

Thanks for considering. 