### PR TITLE
Add support for SQL Server

### DIFF
--- a/docs/drivers.md
+++ b/docs/drivers.md
@@ -4,8 +4,9 @@ title: Drivers
 order: 4
 ---
 
-We currently support three drivers:
+We currently support four drivers:
 
 -   MySQL
 -   SQLite
 -   PostgreSQL
+-   SQL Server

--- a/src/Adapters/AbstractAdapter.php
+++ b/src/Adapters/AbstractAdapter.php
@@ -2,7 +2,14 @@
 
 namespace Flowframe\Trend\Adapters;
 
+use Flowframe\Trend\Trend;
+
 abstract class AbstractAdapter
 {
     abstract public function format(string $column, string $interval): string;
+
+    public function groupColumn(Trend $trend): ?string
+    {
+        return null;
+    }
 }

--- a/src/Adapters/SqlServerAdapter.php
+++ b/src/Adapters/SqlServerAdapter.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Flowframe\Trend\Adapters;
+
+use Error;
+use Flowframe\Trend\Trend;
+
+class SqlServerAdapter extends AbstractAdapter
+{
+    public function format(string $column, string $interval): string
+    {
+        $format = match ($interval) {
+            'minute' => 'yyyy-MM-dd HH:mm:00',
+            'hour' => 'yyyy-MM-dd HH:00',
+            'day' => 'yyyy-MM-dd',
+            'month' => 'yyyy-MM',
+            'year' => 'yyyy',
+            default => throw new Error('Invalid interval.'),
+        };
+
+        return "FORMAT({$column}, '{$format}')";
+    }
+
+    public function groupColumn(Trend $trend): ?string
+    {
+        return $trend->sqlDate;
+    }
+}


### PR DESCRIPTION
First-time collaborator, be gentle. :-)

Since SQL Server is not yet supported, I thought I’d make an attempt at adding support.

Unlike the already supported drivers, SQL Server does not support grouping results by column aliases, which makes things a little trickier and required a few workarounds. The way I got around it was to add a `groupColumn()` method in the abstract adapter, which returns null, and then override that method in the SQL Server adapter, where instead it returns the date calculation. In the base class, an added `groupColumn()` method calls the adapter method and then defaults to the `dateAlias` if the adapter method returns null.