### PR TITLE
Add support for SQL Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ We currently support three drivers:
 -   MySQL
 -   SQLite
 -   PostgreSQL
+-   SQL Server
 
 ## Security Vulnerabilities
 

--- a/src/Adapters/AbstractAdapter.php
+++ b/src/Adapters/AbstractAdapter.php
@@ -2,7 +2,14 @@
 
 namespace Flowframe\Trend\Adapters;
 
+use Flowframe\Trend\Trend;
+
 abstract class AbstractAdapter
 {
     abstract public function format(string $column, string $interval): string;
+
+    public function groupColumn(Trend $trend): ?string
+    {
+        return null;
+    }
 }

--- a/src/Adapters/SqlServerAdapter.php
+++ b/src/Adapters/SqlServerAdapter.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Flowframe\Trend\Adapters;
+
+use Error;
+use Flowframe\Trend\Trend;
+
+class SqlServerAdapter extends AbstractAdapter
+{
+    public function format(string $column, string $interval): string
+    {
+        $format = match ($interval) {
+            'minute' => 'yyyy-MM-dd HH:mm:00',
+            'hour' => 'yyyy-MM-dd HH:00',
+            'day' => 'yyyy-MM-dd',
+            'month' => 'yyyy-MM',
+            'year' => 'yyyy',
+            default => throw new Error('Invalid interval.'),
+        };
+
+        return "FORMAT({$column}, '{$format}')";
+    }
+
+    public function groupColumn(Trend $trend): ?string
+    {
+        return $trend->sqlDate;
+    }
+}


### PR DESCRIPTION
Add support for SQL Server

- Add SqlServerAdapter
- Refactor some functions in the base class to get around the limitation that SQL Server does not support grouping by a column alias, requiring instead a repetition of the calculation
- Update readme file

(Updated from #35 to include changes to documentation.)