### PR TITLE
PostgreSQL adapter bug fix

### DIFF
--- a/src/Adapters/PgsqlAdapter.php
+++ b/src/Adapters/PgsqlAdapter.php
@@ -17,6 +17,6 @@ class PgsqlAdapter extends AbstractAdapter
             default => throw new Error('Invalid interval.'),
         };
 
-        return "to_char({$column}, '{$format}')";
+        return "to_char(\"{$column}\", '{$format}')";
     }
 }


### PR DESCRIPTION
Wrapped the column in double quotes as it is required by Postgres

PostgreSQL 16.2 (Debian 16.2-1.pgdg120+2) on aarch64-unknown-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit