### PR TITLE
Support for SingleStore

### DIFF
--- a/src/Trend.php
+++ b/src/Trend.php
@@ -166,7 +166,7 @@ class Trend
     protected function getSqlDate(): string
     {
         $adapter = match ($this->builder->getConnection()->getDriverName()) {
-            'mysql', 'mariadb' => new MySqlAdapter(),
+            'mysql', 'mariadb', 'singlestore' => new MySqlAdapter(),
             'sqlite' => new SqliteAdapter(),
             'pgsql' => new PgsqlAdapter(),
             default => throw new Error('Unsupported database driver.'),


### PR DESCRIPTION
Since SingleStore uses the same date format as mysql, MySqlAdapter can also be used when using the SingleStore driver.

References: singlestoredb/singlestoredb-laravel