### PR TITLE
Use isoFormat() instead of format() for placeholder dates

### DIFF
--- a/src/Trend.php
+++ b/src/Trend.php
@@ -146,7 +146,7 @@ class Trend
 
         $placeholders = $this->getDatePeriod()->map(
             fn (CarbonInterface $date) => new TrendValue(
-                date: $date->format($this->getCarbonDateFormat()),
+                date: $date->isoFormat($this->getCarbonDateFormat()),
                 aggregate: 0,
             )
         );
@@ -183,13 +183,13 @@ class Trend
     protected function getCarbonDateFormat(): string
     {
         return match ($this->interval) {
-            'minute' => 'Y-m-d H:i:00',
-            'hour' => 'Y-m-d H:00',
-            'day' => 'Y-m-d',
-            'week' => 'Y-W',
-            'month' => 'Y-m',
-            'year' => 'Y',
-            default => throw new Error('Invalid interval.'),
+            'minute' => 'YYYY-MM-DD HH:mm:00',
+            'hour' => 'YYYY-MM-DD HH:00',
+            'day' => 'YYYY-MM-DD',
+            'week' => 'GGGG-WW',
+            'month' => 'YYYY-MM',
+            'year' => 'YYYY',
+            default => throw new Error('Invalid interval. Possible intervals: "minute", "hour", "day", "week", "month", "year".')
         };
     }
 }


### PR DESCRIPTION
### What
This PR fixes an issue with incorrect year numbers on placeholder dates formatted in weeks belonging to the previous year.

### Why
By default, using format("Y-W") will return the year of the current date, even if the week is technically part of the previous year. To fix this and to account for the ISO-8601 year, which can differ from the calendar year. Carbon provides the isoFormat method, which respects the ISO-8601 standard for both the year and the week.

E.g. "2022-01-02" is actually "2021-52", however the currently used method would incorrectly output "2022-52".

### How
Using isoFormat() instead of format() methods of Carbon Date object together with the ISO date formatting string "GGGG-WW" solves this issue