### PR TITLE
Add timezone() Support to Laravel Trend for Custom Timezone Aggregations

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,22 @@ You can use the following aggregates:
 -   `min('column')`
 -   `count('*')`
 
+## Timezone
+
+Use the `timezone()` method to set a custom timezone for the date aggregation operations. This is particularly useful if you need to align data trends with a specific regional timezone.
+
+Example:
+
+```php
+Trend::model(Order::class)
+    ->timezone('Asia/Dhaka')
+    ->between(...)
+    ->perDay()
+    ->count();
+```
+
+This example will perform the aggregation operations in the "Asia/Dhaka" timezone, adjusting all date-based intervals accordingly.
+
 ## Date Column
 
 By default, laravel-trend assumes that the model on which the operation is being performed has a `created_at` date column. If your model uses a different column name for the date or you want to use a different one, you should specify it using the `dateColumn(string $column)` method.

--- a/src/Adapters/AbstractAdapter.php
+++ b/src/Adapters/AbstractAdapter.php
@@ -4,5 +4,5 @@ namespace Flowframe\Trend\Adapters;
 
 abstract class AbstractAdapter
 {
-    abstract public function format(string $column, string $interval): string;
+    abstract public function format(string $column, string $interval, string $timezone): string;
 }

--- a/src/Adapters/MySqlAdapter.php
+++ b/src/Adapters/MySqlAdapter.php
@@ -6,7 +6,7 @@ use Error;
 
 class MySqlAdapter extends AbstractAdapter
 {
-    public function format(string $column, string $interval): string
+    public function format(string $column, string $interval, string $timezone): string
     {
         $format = match ($interval) {
             'minute' => '%Y-%m-%d %H:%i:00',
@@ -17,6 +17,10 @@ class MySqlAdapter extends AbstractAdapter
             'year' => '%Y',
             default => throw new Error('Invalid interval.'),
         };
+
+        if ($timezone !== 'UTC') {
+            return "date_format(CONVERT_TZ({$column}, 'UTC', '{$timezone}'), '{$format}')";
+        }
 
         return "date_format({$column}, '{$format}')";
     }

--- a/src/Adapters/PgsqlAdapter.php
+++ b/src/Adapters/PgsqlAdapter.php
@@ -6,7 +6,7 @@ use Error;
 
 class PgsqlAdapter extends AbstractAdapter
 {
-    public function format(string $column, string $interval): string
+    public function format(string $column, string $interval, string $timezone): string
     {
         $format = match ($interval) {
             'minute' => 'YYYY-MM-DD HH24:MI:00',
@@ -17,6 +17,10 @@ class PgsqlAdapter extends AbstractAdapter
             'year' => 'YYYY',
             default => throw new Error('Invalid interval.'),
         };
+
+        if ($timezone !== 'UTC') {
+            return "to_char(\"{$column}\" AT TIME ZONE 'UTC' AT TIME ZONE '{$timezone}', '{$format}')";
+        }
 
         return "to_char(\"{$column}\", '{$format}')";
     }

--- a/src/Adapters/SqliteAdapter.php
+++ b/src/Adapters/SqliteAdapter.php
@@ -6,7 +6,7 @@ use Error;
 
 class SqliteAdapter extends AbstractAdapter
 {
-    public function format(string $column, string $interval): string
+    public function format(string $column, string $interval, string $timezone): string
     {
         $format = match ($interval) {
             'minute' => '%Y-%m-%d %H:%M:00',

--- a/src/Trend.php
+++ b/src/Trend.php
@@ -23,6 +23,8 @@ class Trend
 
     public string $dateAlias = 'date';
 
+    public string $timezone = 'UTC';
+
     public function __construct(public Builder $builder)
     {
     }
@@ -92,6 +94,13 @@ class Trend
     public function dateAlias(string $alias): self
     {
         $this->dateAlias = $alias;
+
+        return $this;
+    }
+
+    public function timezone(string $timezone): self
+    {
+        $this->timezone = $timezone;
 
         return $this;
     }
@@ -177,7 +186,7 @@ class Trend
             default => throw new Error('Unsupported database driver.'),
         };
 
-        return $adapter->format($this->dateColumn, $this->interval);
+        return $adapter->format($this->dateColumn, $this->interval, $this->timezone);
     }
 
     protected function getCarbonDateFormat(): string


### PR DESCRIPTION
This update introduces the `timezone()` method to Laravel Trend, allowing users to specify a custom timezone for date aggregation operations. By setting a timezone, all date-based intervals (`perMinute()`, `perDay()`, etc.) are adjusted to the specified region, providing accurate data trends for specific time zones. This addition is especially beneficial for applications where data trends need to be localized, such as setting the timezone to "Asia/Dhaka" for users in Bangladesh. 

Example usage:

```php
Trend::model(Order::class)
    ->timezone('Asia/Dhaka')
    ->between(...)
    ->perDay()
    ->count();
```