### PR TITLE
fix: SqliteAdapter wrong week format fix #81

### DIFF
--- a/src/Adapters/SqliteAdapter.php
+++ b/src/Adapters/SqliteAdapter.php
@@ -8,6 +8,12 @@ class SqliteAdapter extends AbstractAdapter
 {
     public function format(string $column, string $interval): string
     {
+        // Fix wrong week date format after SQLite v3.46
+        // Using coalesce for backward compatibility
+        if ($interval === 'week') {
+            return "coalesce(strftime('%G-%V', {$column}), strftime('%Y-%W', {$column}))";
+        }
+
         $format = match ($interval) {
             'minute' => '%Y-%m-%d %H:%M:00',
             'hour' => '%Y-%m-%d %H:00',


### PR DESCRIPTION
The actual date format for the SQLiteAdapter is this one:
https://github.com/Flowframe/laravel-trend/blob/391849c27a1d4791efae930746a51d982820bd3a/src/Adapters/SqliteAdapter.php#L15
But this causes an issue as it's a non ISO 8601 date format as stated in [the SQLite documentation](https://www.sqlite.org/lang_datefunc.html).

The correct format should be `%G-%V` but is only available after the version 3.46 which is relatively new less than a year, not the default version for Ubuntu 24.04 and by cascading laravel/sail.

In the case where the date format is not recognized (if you run under the ISO 8601 supported version), it returns null as stated in the documentation.
So I used the coalesce method to parse for both format to enforce backward compatibility.