### PR TITLE
Allow JSON columns to be used as the dateColumn in MySQL

### DIFF
--- a/src/Adapters/MySqlAdapter.php
+++ b/src/Adapters/MySqlAdapter.php
@@ -3,6 +3,7 @@
 namespace Flowframe\Trend\Adapters;
 
 use Error;
+use Illuminate\Database\Query\Grammars\MySqlGrammar;
 
 class MySqlAdapter extends AbstractAdapter
 {
@@ -17,7 +18,8 @@ class MySqlAdapter extends AbstractAdapter
             'year' => '%Y',
             default => throw new Error('Invalid interval.'),
         };
-
-        return "date_format({$column}, '{$format}')";
+        
+        $wrappedColumn = (new MySqlGrammar)->wrap($column);
+        return "date_format({$wrappedColumn}, '{$format}')";
     }
 }


### PR DESCRIPTION
### What
This PR allows passes the dateColumn through the Illuminate MySQL grammar wrapper so that you can use JSON columns. Fixes https://github.com/Flowframe/laravel-trend/issues/71

![image](https://github.com/user-attachments/assets/6d78d67a-90f5-4b7a-9706-88cc69031cf9)

### Why
We have dates in JSON columns that we would like to use to trend. The "where_between" call already allows this but the "date_format" does not.

### How
Simply call the MySqlGrammar->wrap instead of injecting the string directly into the date format call.

