### PR TITLE
Fix Week formatting issue when date range spans across two years

### DIFF
--- a/src/Trend.php
+++ b/src/Trend.php
@@ -146,7 +146,7 @@ class Trend
 
         $placeholders = $this->getDatePeriod()->map(
             fn (CarbonInterface $date) => new TrendValue(
-                date: $date->format($this->getCarbonDateFormat()),
+                date: $date->format($this->getCarbonDateFormat($date)),
                 aggregate: 0,
             )
         );
@@ -180,16 +180,23 @@ class Trend
         return $adapter->format($this->dateColumn, $this->interval);
     }
 
-    protected function getCarbonDateFormat(): string
+    protected function getCarbonDateFormat(CarbonInterface $date): string
     {
-        return match ($this->interval) {
-            'minute' => 'Y-m-d H:i:00',
-            'hour' => 'Y-m-d H:00',
-            'day' => 'Y-m-d',
-            'week' => 'Y-W',
-            'month' => 'Y-m',
-            'year' => 'Y',
+        return (match ($this->interval) {
+            'minute' => fn() => 'Y-m-d H:i:00',
+            'hour' => fn() => 'Y-m-d H:00',
+            'day' => fn() => 'Y-m-d',
+            'week' => function(CarbonInterface $date) {
+                // Handle the special case for week 53 of the year
+                // when the week starts in December and ends in January of the next year.
+                if ($date->week === 1 && $date->month === 12 && $this->interval === 'week') {
+                    return 'Y-53';
+                }
+                return 'Y-W';
+            },
+            'month' => fn() => 'Y-m',
+            'year' => fn() => 'Y',
             default => throw new Error('Invalid interval.'),
-        };
+        })($date);
     }
 }


### PR DESCRIPTION
This PR addresses a bug occurring when:
	•	The selected interval is "week",
	•	The date range spans across two years (e.g. from December 23, 2024 to January 12, 2025).

## Problem

In such a case, PHP’s $date->format('Y-W') can return “2024-01” for the week starting on Monday, December 30, 2024 and ending on Sunday, January 5, 2025.
Although the date is still in 2024, the ISO week number is 1, which typically refers to the first week of the following year. This leads to inconsistent keys when compared to those returned by MySQL.

Example returned by mapValuesToDates():

```php
[
  "2024-01",  // Incorrect value from $placeholders
  "2024-52",
  "2024-53",  // Week properly returned by MySQL
  "2025-01",
  "2025-02"
]
```

Quick test : 
```php
collect(CarbonPeriod::between(
                '2024-12-23',
                '2025-01-12',
            )->interval("1 week"))
                ->map(function ($date) {
                    return $date->format('Y-m-d') . ' - ' . $date->format('Y-W');
                })
```

## Fix

This PR ensures $placeholders uses consistent week-year formatting that aligns with ISO 8601 and MySQL outputs.
Now, for a week that starts on Dec 30, 2024, the returned key will be “2024-53”, not “2024-01”.

## ⚠️ Note on MySQL behavior

It is worth noting that MySQL may return two distinct keys for the same week: "2024-53" and "2025-01".
As a result, we end up with two items in the collection for what is essentially the same week.

This is particularly problematic when rendering data in line charts, as it leads to data duplication and visual inconsistencies.

➡️ A separate pull request will be created to address this specific issue.
