### PR TITLE
Merge duplicate weeks spanning across two years (week 53 and week 01)

### DIFF
--- a/src/Trend.php
+++ b/src/Trend.php
@@ -178,7 +178,6 @@ class Trend
 
                 return $carry;
             }, collect())
-            ->dd()
             ->flatten();
     }
 

--- a/src/Trend.php
+++ b/src/Trend.php
@@ -155,6 +155,30 @@ class Trend
             ->merge($placeholders)
             ->unique('date')
             ->sort()
+            ->reduce(function (Collection $carry, TrendValue $trendValue) {
+                if ($this->interval !== 'week') {
+                    $carry->push($trendValue);
+                    return $carry;
+                }
+
+                [
+                    $year,
+                    $month,
+                ] = explode('-', $trendValue->date);
+                // Handle the special case for week 53 of the year
+                // when the week starts in December and ends in January of the next year merge with the first week of the next year.
+                if ($month == '01') {
+                    if ($lastIndex = $carry->search(fn (TrendValue $value) => $value->date === ($year - 1) . '-53')) {
+                        $last = $carry->get($lastIndex);
+                        $trendValue->aggregate += $last->aggregate;
+                        $carry->splice($lastIndex, 1);
+                    }
+                }
+                $carry->push($trendValue);
+
+                return $carry;
+            }, collect())
+            ->dd()
             ->flatten();
     }
 


### PR DESCRIPTION
This PR is a follow-up to [#86](https://github.com/Flowframe/laravel-trend/pull/86), which addressed the formatting issue when week intervals span two years.

## Problem

Even with correct week-year formatting, MySQL may return two distinct keys for the same ISO week: for instance, both "2024-53" and "2025-01" can refer to the same 7-day period starting on Monday, December 30, 2024 and ending on Sunday, January 5, 2025.

This leads to:
	•	Two TrendValue items for the same week, which is incorrect.
	•	Duplicate data in visual representations, especially line charts, which expect unique and continuous labels on the X-axis.

## Fix

This PR merges the two values into a single entry