### PR TITLE
Support Date Column in Unix Epoch Timestamp Format

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,19 @@ Trend::model(Order::class)
 
 This allows you to work with models that have custom date column names or when you want to analyze data based on a different date column.
 
+If your date column stores Unix timestamps (integer seconds since epoch), use `dateColumnIsUnixTimestamp()`.
+
+Example:
+
+```php
+Trend::model(Order::class)
+    ->dateColumn('custom_date_column')
+    ->dateColumnIsUnixTimestamp()
+    ->between(...)
+    ->perDay()
+    ->count();
+```
+
 ## Drivers
 
 We currently support four drivers:

--- a/src/Adapters/AbstractAdapter.php
+++ b/src/Adapters/AbstractAdapter.php
@@ -4,5 +4,5 @@ namespace Flowframe\Trend\Adapters;
 
 abstract class AbstractAdapter
 {
-    abstract public function format(string $column, string $interval): string;
+    abstract public function format(string $column, string $interval, bool $isUnixTimestamp = false): string;
 }

--- a/src/Adapters/MySqlAdapter.php
+++ b/src/Adapters/MySqlAdapter.php
@@ -6,7 +6,7 @@ use Error;
 
 class MySqlAdapter extends AbstractAdapter
 {
-    public function format(string $column, string $interval): string
+    public function format(string $column, string $interval, bool $isUnixTimestamp = false): string
     {
         $format = match ($interval) {
             'minute' => '%Y-%m-%d %H:%i:00',
@@ -18,6 +18,8 @@ class MySqlAdapter extends AbstractAdapter
             default => throw new Error('Invalid interval.'),
         };
 
-        return "date_format({$column}, '{$format}')";
+        $columnExpression = $isUnixTimestamp ? "FROM_UNIXTIME({$column})" : $column;
+
+        return "date_format({$columnExpression}, '{$format}')";
     }
 }

--- a/src/Adapters/PgsqlAdapter.php
+++ b/src/Adapters/PgsqlAdapter.php
@@ -6,7 +6,7 @@ use Error;
 
 class PgsqlAdapter extends AbstractAdapter
 {
-    public function format(string $column, string $interval): string
+    public function format(string $column, string $interval, bool $isUnixTimestamp = false): string
     {
         $format = match ($interval) {
             'minute' => 'YYYY-MM-DD HH24:MI:00',
@@ -18,6 +18,8 @@ class PgsqlAdapter extends AbstractAdapter
             default => throw new Error('Invalid interval.'),
         };
 
-        return "to_char(\"{$column}\", '{$format}')";
+        $columnExpression = $isUnixTimestamp ? "TO_TIMESTAMP({$column})" : "\"{$column}\"";
+
+        return "to_char({$columnExpression}, '{$format}')";
     }
 }

--- a/src/Adapters/SqliteAdapter.php
+++ b/src/Adapters/SqliteAdapter.php
@@ -6,7 +6,7 @@ use Error;
 
 class SqliteAdapter extends AbstractAdapter
 {
-    public function format(string $column, string $interval): string
+    public function format(string $column, string $interval, bool $isUnixTimestamp = false): string
     {
         $format = match ($interval) {
             'minute' => '%Y-%m-%d %H:%M:00',
@@ -18,6 +18,8 @@ class SqliteAdapter extends AbstractAdapter
             default => throw new Error('Invalid interval.'),
         };
 
-        return "strftime('{$format}', {$column})";
+        $columnExpression = $isUnixTimestamp ? "{$column}, 'unixepoch'" : $column;
+
+        return "strftime('{$format}', {$columnExpression})";
     }
 }

--- a/src/Trend.php
+++ b/src/Trend.php
@@ -23,6 +23,8 @@ class Trend
 
     public string $dateAlias = 'date';
 
+    public bool $dateColumnIsUnixTimestamp = false;
+
     public function __construct(public Builder $builder)
     {
     }
@@ -96,6 +98,13 @@ class Trend
         return $this;
     }
 
+    public function dateColumnIsUnixTimestamp(bool $isUnixTimestamp = true): self
+    {
+        $this->dateColumnIsUnixTimestamp = $isUnixTimestamp;
+
+        return $this;
+    }
+
     public function aggregate(string $column, string $aggregate): Collection
     {
         $values = $this->builder
@@ -104,7 +113,12 @@ class Trend
                 {$this->getSqlDate()} as {$this->dateAlias},
                 {$aggregate}({$column}) as aggregate
             ")
-            ->whereBetween($this->dateColumn, [$this->start, $this->end])
+            ->whereBetween(
+                $this->dateColumn,
+                $this->dateColumnIsUnixTimestamp
+                    ? [$this->start->timestamp, $this->end->timestamp]
+                    : [$this->start, $this->end]
+            )
             ->groupBy($this->dateAlias)
             ->orderBy($this->dateAlias)
             ->get();
@@ -177,7 +191,11 @@ class Trend
             default => throw new Error('Unsupported database driver.'),
         };
 
-        return $adapter->format($this->dateColumn, $this->interval);
+        return $adapter->format(
+            $this->dateColumn,
+            $this->interval,
+            $this->dateColumnIsUnixTimestamp,
+        );
     }
 
     protected function getCarbonDateFormat(): string


### PR DESCRIPTION
# Add support for Unix timestamp date columns

This PR adds support for Unix timestamp (integer) date columns, allowing trends to be generated directly from timestamp-based fields in addition to standard datetime columns.

## Use Case / Motivation

There are major PHP-based systems and **frameworks like the [Typo3 CMS](https://typo3.org/) that store dates as Unix timestamps.** Because of that, I personally (and I assume others too) **need support for this.**

## Usage Example (I added it to the README, too)

If your date column stores Unix timestamps (integer seconds since epoch), use `dateColumnIsUnixTimestamp()`.

Example:

```php
Trend::model(Order::class)
    ->dateColumn('custom_date_column')
    ->dateColumnIsUnixTimestamp()
    ->between(...)
    ->perDay()
    ->count();
```